### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
         "php-http/socket-client": "^2.0",
         "php-http/client-common": "^2.1",
         "php-http/message": "^1.0",
-        "guzzlehttp/psr7": "^1.2",
-        "symfony/yaml": "^3.2||^4.0||^5.0"
+        "guzzlehttp/psr7": "^1.2||^2.0",
+        "symfony/yaml": "^3.2||^4.0||^5.0||^6.0"
     },
     "require-dev": {
         "symfony/debug": "*",


### PR DESCRIPTION
moving the problems here then :)

i hope this solvers

```
    - julianosorio078/cups-ipp 0.9 requires guzzlehttp/psr7 ^1.2 -> found guzzlehttp/psr7[1.2.0, ..., 1.9.0] but the package is fixed to 2.4.3 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
```