### PR TITLE
Update Job.php

### DIFF
--- a/src/Model/Job.php
+++ b/src/Model/Job.php
@@ -276,6 +276,7 @@ class Job implements JobInterface
           'name' => $name,
           'mimeType' => $mimeType,
           'filename' => $filename,
+          'binary' => file_get_contents($filename),
         ];
 
         return $this;


### PR DESCRIPTION
In JobManager.php:625 $part['binary'] is undefined if printing a file The file_get_contents does the job - however, it could be refactored using fopen instead which may be more stable